### PR TITLE
activation: fix image list issue when activating BIOS image

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -199,6 +199,12 @@ auto Activation::activation(Activations value) -> Activations
 
         // Create active association
         parent.createActiveAssociation(path);
+        auto purpose = parent.getVersionPurpose(versionId);
+        if (purpose != server::Version::VersionPurpose::BMC)
+        {
+            log<level::WARNING>("Only BIOS image need to create FunctionaAssociation");
+            parent.createFunctionalAssociation(path);
+        }
 
         if (Activation::checkApplyTimeImmediate() == true)
         {

--- a/item_updater.cpp
+++ b/item_updater.cpp
@@ -261,7 +261,6 @@ void ItemUpdater::processBMCImage()
                 associations.emplace_back(std::make_tuple(
                     ACTIVATION_FWD_ASSOCIATION, ACTIVATION_REV_ASSOCIATION,
                     bmcInventoryPath));
-
                 // Create an active association since this image is active
                 createActiveAssociation(path);
             }
@@ -342,7 +341,7 @@ void ItemUpdater::erase(std::string entryId)
     auto it = versions.find(entryId);
     if (it != versions.end())
     {
-        if (it->second->isFunctional() && ACTIVE_BMC_MAX_ALLOWED >= 1)
+        if (it->second->isFunctional() && ACTIVE_BMC_MAX_ALLOWED > 1)
         {
             log<level::ERR>("Error: Version is currently running on the BMC. "
                             "Unable to remove.",
@@ -703,7 +702,11 @@ void ItemUpdater::freeSpace(Activation& caller)
             if ((versions.find(iter.second->versionId)
                      ->second->isFunctional() &&
                  ACTIVE_BMC_MAX_ALLOWED > 1) ||
-                (iter.second->versionId == caller.versionId))
+                (iter.second->versionId == caller.versionId) ||
+                 (versions.find(iter.second->versionId)
+                     ->second->purpose() == server::Version::VersionPurpose::BMC &&
+                 versions.find(iter.second->versionId)
+                     ->second->isFunctional()))
             {
                 continue;
             }

--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -116,6 +116,13 @@ class ItemUpdater : public ItemUpdaterInherit
      */
     void createActiveAssociation(const std::string& path);
 
+    /** @brief Creates a functional association to the
+     *  "running" BMC software image
+     *
+     * @param[in]  path - The path to create the association to.
+     */
+    void createFunctionalAssociation(const std::string& path);
+
     /** @brief Removes the associations from the provided software image path
      *
      * @param[in]  path - The path to remove the associations from.
@@ -208,13 +215,6 @@ class ItemUpdater : public ItemUpdaterInherit
 
     /** @brief Restores field mode status on reboot. */
     void restoreFieldModeStatus();
-
-    /** @brief Creates a functional association to the
-     *  "running" BMC software image
-     *
-     * @param[in]  path - The path to create the association to.
-     */
-    void createFunctionalAssociation(const std::string& path);
 
     /** @brief Persistent sdbusplus D-Bus bus connection. */
     sdbusplus::bus::bus& bus;


### PR DESCRIPTION
    1.keep BMC functional image in image list
    2.keep BIOS active image in image list
    3.remove BIOS functional image in image list

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>