### PR TITLE
Implement update host version method

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,8 +32,11 @@ phosphor_version_software_manager_SOURCES = \
 
 BUILT_SOURCES = \
 	xyz/openbmc_project/Software/Image/error.cpp \
-	xyz/openbmc_project/Software/Image/error.hpp
+	xyz/openbmc_project/Software/Image/error.hpp \
+	xyz/openbmc_project/Software/HostVer/server.cpp \
+	xyz/openbmc_project/Software/HostVer/server.hpp
 
+nodist_include_HEADERS = xyz/openbmc_project/Software/HostVer/server.hpp
 CLEANFILES = ${BUILT_SOURCES}
 
 phosphor_download_manager_SOURCES = \
@@ -46,7 +49,8 @@ phosphor_image_updater_SOURCES = \
 	serialize.cpp \
 	item_updater.cpp \
 	item_updater_main.cpp \
-	utils.cpp
+	utils.cpp \
+	xyz/openbmc_project/Software/HostVer/server.cpp
 
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
@@ -113,6 +117,14 @@ xyz/openbmc_project/Software/Image/error.hpp: ${top_srcdir}/xyz/openbmc_project/
 xyz/openbmc_project/Software/Image/error.cpp: ${top_srcdir}/xyz/openbmc_project/Software/Image.errors.yaml
 	@mkdir -p `dirname $@`
 	$(SDBUSPLUSPLUS) -r $(srcdir) error exception-cpp xyz.openbmc_project.Software.Image > $@
+
+xyz/openbmc_project/Software/HostVer/server.cpp: ${top_srcdir}/xyz/openbmc_project/Software/HostVer.interface.yaml
+	@mkdir -p `dirname $@`
+	$(SDBUSPLUSPLUS) -r $(top_srcdir) interface server-cpp xyz.openbmc_project.Software.HostVer > $@
+
+xyz/openbmc_project/Software/HostVer/server.hpp: ${top_srcdir}/xyz/openbmc_project/Software/HostVer.interface.yaml
+	@mkdir -p `dirname $@`
+	$(SDBUSPLUSPLUS) -r $(top_srcdir) interface server-header xyz.openbmc_project.Software.HostVer > $@
 
 phosphor_version_software_manager_CXXFLAGS = $(generic_cxxflags)
 phosphor_version_software_manager_LDFLAGS = $(generic_ldflags)

--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -5,6 +5,7 @@
 #include "version.hpp"
 #include "xyz/openbmc_project/Collection/DeleteAll/server.hpp"
 #include "xyz/openbmc_project/Software/Version/server.hpp"
+#include "xyz/openbmc_project/Software/HostVer/server.hpp"
 
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Association/Definitions/server.hpp>
@@ -22,12 +23,15 @@ using ItemUpdaterInherit = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::FactoryReset,
     sdbusplus::xyz::openbmc_project::Control::server::FieldMode,
     sdbusplus::xyz::openbmc_project::Association::server::Definitions,
-    sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
+    sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll,
+    sdbusplus::xyz::openbmc_project::Software::server::HostVer>;
 
 namespace MatchRules = sdbusplus::bus::match::rules;
 using VersionClass = phosphor::software::manager::Version;
 using AssociationList =
     std::vector<std::tuple<std::string, std::string, std::string>>;
+
+constexpr auto INVALID_VERSION = "N/A";
 
 namespace server = sdbusplus::xyz::openbmc_project::Software::server;
 
@@ -164,7 +168,14 @@ class ItemUpdater : public ItemUpdaterInherit
      * @param[in] caller - The Activation object that called this function.
      */
     void freeSpace(Activation& caller);
+
+    /** @brief Find the version purpose by version ID
+     *
+     * @param[in] versionId  - the purpose mapping version ID
+     */
     server::Version::VersionPurpose getVersionPurpose(const std::string& versionId);
+    void updateHostVer(std::string) override;
+
 
   private:
     /** @brief Callback function for Software.Version match.
@@ -247,6 +258,7 @@ class ItemUpdater : public ItemUpdaterInherit
      *  alternate chip.
      */
     void mirrorUbootToAlt();
+    void createHostVersion(const std::string& version);
 };
 
 } // namespace updater

--- a/static/flash.cpp
+++ b/static/flash.cpp
@@ -6,6 +6,7 @@
 #include "images.hpp"
 
 #include <experimental/filesystem>
+#include <phosphor-logging/log.hpp>
 
 namespace
 {
@@ -18,7 +19,7 @@ namespace software
 {
 namespace updater
 {
-
+using namespace phosphor::logging;
 namespace fs = std::experimental::filesystem;
 
 void Activation::flashWrite()
@@ -42,7 +43,15 @@ void Activation::flashWrite()
                 auto method = bus.new_method_call(SYSTEMD_BUSNAME, SYSTEMD_PATH,
                                       SYSTEMD_INTERFACE, "StartUnit");
                 method.append(serviceFile, "replace");
-                auto rerply = bus.call(method);
+                try
+                {
+                    auto reply = bus.call(method);
+                }
+                catch(const std::exception& e)
+                {
+                    log<level::ERR>("Error in starting flash bios service",
+                        entry("WHAT=%s", e.what()));
+                }
             }
             else
                 fs::copy_file(uploadDir / versionId / bmcImage, toPath / bmcImage,

--- a/xyz/openbmc_project/Software/HostVer.interface.yaml
+++ b/xyz/openbmc_project/Software/HostVer.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    Implement to update BIOS version from ipmid.
+methods:
+    - name: UpdateHostVer
+      description: >
+          Create or update host version
+      parameters:
+        - name: version
+          type: string
+          description: >
+              version from ipmid


### PR DESCRIPTION
Add internal interface HostVer to export new method for ipmid update host version.
Default bios-release "N/A" will be ignore via processHostImage.
The activation and version object will create after ipmid pass real version.

Signed-off-by: Brian Ma <chma0@nuvoton.com>