### PR TITLE
Support image-bmc for BMC firmware update

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -122,6 +122,12 @@ bool Signature::verify()
                     return false;
                 }
             }
+            else if ( fs::exists(file) && ! fs::exists(sigFile) )
+            {
+                log<level::ERR>("Image file Signature is not exist",
+                                entry("IMAGE=%s", bmcImage.c_str()));
+                return false;
+            }
         }
 
         log<level::DEBUG>("Successfully completed Signature vaildation.");

--- a/images.hpp
+++ b/images.hpp
@@ -13,8 +13,8 @@ namespace image
 // BMC flash image file name list.
 const std::vector<std::string> bmcImages = {"image-kernel", "image-rofs",
                                             "image-rwfs", "image-u-boot",
-                                            "image-bios"};
-
+                                            "image-bmc", "image-bios",
+                                            };
 
 } // namespace image
 } // namespace software

--- a/static/flash.cpp
+++ b/static/flash.cpp
@@ -27,6 +27,7 @@ using namespace phosphor::logging;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 namespace fs = std::experimental::filesystem;
+auto constexpr FULL_IMAGE = "image-bmc";
 
 void Activation::flashWrite()
 {
@@ -36,6 +37,12 @@ void Activation::flashWrite()
     fs::path uploadDir(IMG_UPLOAD_DIR);
     fs::path toPath(PATH_INITRAMFS);
 
+    if ( fs::exists(uploadDir / versionId / FULL_IMAGE))
+    {
+        fs::copy_file(uploadDir / versionId / FULL_IMAGE, toPath / FULL_IMAGE,
+                            fs::copy_options::overwrite_existing);
+        return;
+    }
     for (auto& bmcImage : phosphor::software::image::bmcImages)
     {
         if ( fs::exists(uploadDir / versionId / bmcImage))


### PR DESCRIPTION
If user upload image like obmc-phosphor-image-olympus-nuvoton.static.mtd.all.tar,
now the phosphor software manager will support it for update BMC firmware.

Signed-off-by: Brian Ma <chma0@nuvoton.com>