### PR TITLE
start BMC Updater service after obmc-read-eeprom service

### DIFF
--- a/xyz.openbmc_project.Software.BMC.Updater.service
+++ b/xyz.openbmc_project.Software.BMC.Updater.service
@@ -4,7 +4,8 @@ Wants=xyz.openbmc_project.Software.Version.service
 Before=xyz.openbmc_project.Software.Version.service
 Wants=obmc-mapper.target
 After=obmc-mapper.target
-After=mapper-wait@-xyz-openbmc_project-inventory.service
+After=obmc-read-eeprom@system-chassis-bmc.service
+After=obmc-read-eeprom@system-chassis-motherboard.service
 
 [Service]
 ExecStart=/usr/bin/phosphor-image-updater


### PR DESCRIPTION
obmc-read-eeprom service will read fru from eeprom to construct bmc
and motherboard inventory object path.

BMC updater needs to create assocations to bmc/motherboard inventory.

Signed-off-by: Stanley Chu <yschu@nuvoton.com>