### PR TITLE
Handle host activation state is not active in updateHostVer

### DIFF
--- a/activation.hpp
+++ b/activation.hpp
@@ -377,6 +377,11 @@ class HostActivation : public Activation
         log<level::DEBUG>("HostActivation::constructor");
         biosFlashed = false;
     }
+
+    ~HostActivation()
+    {
+        log<level::DEBUG>("HostActivation::destructor");
+    }
     // NOTE: below override functions already declare as virtual function,
     //       in base class, so we don't need change more things.
 


### PR DESCRIPTION
In some error state, we may get BIOS version from IPMI while bios
update progress or others. Handle this kind of errors for keep system
work well.

Signed-off-by: Brian Ma <chma0@nuvoton.com>